### PR TITLE
feature: add local client for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  compile:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,3 +24,5 @@ jobs:
           FERN_TOKEN: dummy
       - name: Compile
         run: ./gradlew compileJava
+      - name: Unit Test
+        run: ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+out/
 .gradle
 *.ipr
 *.iws
@@ -7,4 +8,5 @@ build/
 .DS_Store
 
 # generated code
-src/main/java/com/example/generated/
+src/main/java/com/example/server/generated
+src/test/java/com/example/client/generated

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+    testImplementation 'com.squareup.okhttp3:okhttp:4.9.3'
 }
 
 test {

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -3,9 +3,16 @@ groups:
   local:
     generators:
       - name: fernapi/fern-java-spring
-        version: 0.0.134
+        version: 0.2.1-rc1
         output:
           location: local-file-system
-          path: ../../src/main/java/com/example/generated
+          path: ../../src/main/java/com/example/server/generated
         config:
-          package-prefix: com.example.generated
+          package-prefix: com.example.server.generated
+      - name: fernapi/fern-java-sdk
+        version: 0.2.1-rc1
+        output:
+          location: local-file-system
+          path: ../../src/test/java/com/example/client/generated
+        config:
+          package-prefix: com.example.client.generated

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -3,14 +3,14 @@ groups:
   local:
     generators:
       - name: fernapi/fern-java-spring
-        version: 0.2.1-rc1
+        version: 0.2.1
         output:
           location: local-file-system
           path: ../../src/main/java/com/example/server/generated
         config:
           package-prefix: com.example.server.generated
       - name: fernapi/fern-java-sdk
-        version: 0.2.1-rc1
+        version: 0.2.1
         output:
           location: local-file-system
           path: ../../src/test/java/com/example/client/generated

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-    "organization": "demo",
-    "version": "0.5.1"
+  "organization": "demo",
+  "version": "0.6.12"
 }

--- a/src/main/java/com/example/ImdbController.java
+++ b/src/main/java/com/example/ImdbController.java
@@ -1,9 +1,9 @@
 package com.example;
 
-import com.example.generated.resources.imdb.ImdbService;
-import com.example.generated.resources.imdb.types.CreateMovieRequest;
-import com.example.generated.resources.imdb.types.Movie;
-import com.example.generated.resources.imdb.types.MovieId;
+import com.example.server.generated.resources.imdb.ImdbService;
+import com.example.server.generated.resources.imdb.types.CreateMovieRequest;
+import com.example.server.generated.resources.imdb.types.Movie;
+import com.example.server.generated.resources.imdb.types.MovieId;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,7 +18,7 @@ public final class ImdbController implements ImdbService {
     public Movie getMovie(MovieId movieId) {
         return Movie.builder()
                 .id(movieId)
-                .title("Goodwill hunting")
+                .title("Goodwill Hunting")
                 .rating(10.9)
                 .build();
     }

--- a/src/test/java/com/example/ApplicationTest.java
+++ b/src/test/java/com/example/ApplicationTest.java
@@ -21,7 +21,7 @@ public class ApplicationTest {
         DemoApiClient client = DemoApiClient.builder()
                 .url("http://localhost:8080")
                 .build();
-        Movie movie = client.imdb().getMovie("oodwill-hunting");
+        Movie movie = client.imdb().getMovie("goodwill-hunting");
         Assertions.assertEquals(movie.getTitle(), "Goodwill Hunting");
     }
 }

--- a/src/test/java/com/example/ApplicationTest.java
+++ b/src/test/java/com/example/ApplicationTest.java
@@ -1,0 +1,27 @@
+package com.example;
+
+
+import com.example.client.generated.DemoApiClient;
+import com.example.client.generated.resources.imdb.types.Movie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+
+public class ApplicationTest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        SpringApplication.run(Application.class);
+    }
+
+
+    @Test
+    public void test() {
+        DemoApiClient client = DemoApiClient.builder()
+                .url("http://localhost:8080")
+                .build();
+        Movie movie = client.imdb().getMovie("oodwill-hunting");
+        Assertions.assertEquals(movie.getTitle(), "Goodwill Hunting");
+    }
+}


### PR DESCRIPTION
This PR adds the `fernapi/fern-java-sdk` generator. Fern will generate a Java client and dump the files to the specified path. The generated java client can then be used to unit-testing or end-to-end testing. 