### PR TITLE
Use fern-api/setup-fern-cli@v1 action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
           cache: 'gradle'
-      - name: Install fern
-        run: npm install -g fern-api
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
       - name: fern generate
         run: fern generate
         env:


### PR DESCRIPTION
## Summary

- Replaces the manual `npm install -g fern-api` step with the `fern-api/setup-fern-cli@v1` GitHub Action
- No `setup-node` step is needed since GitHub-hosted `ubuntu-latest` runners include Node.js by default

## Test plan

- [ ] Verify the CI workflow passes on this PR
- [ ] Confirm the `fern generate` step runs successfully using the action-installed CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)